### PR TITLE
Fix start order using start.sh, refactor docker-compose.yaml variable handling, modify Dockerfile to use start.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,27 @@
-# Use Node.js ARM64 image
 FROM --platform=linux/arm64 node:20-slim
 
-# Install OpenSSL
 RUN apt-get update -y && apt-get install -y openssl
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
 COPY prisma ./prisma/
 
-# Install dependencies
 RUN npm install
 
-# Copy the rest of the application
 COPY . .
 
-# Generate Prisma client
 RUN npx prisma generate
 
-# Build the Next.js application
 RUN npm run build
 
-# Set up standalone output
 RUN mkdir -p .next/standalone/.next/static && \
     cp -r .next/static/* .next/standalone/.next/static/ && \
     mkdir -p .next/standalone/public && \
     cp -r public/* .next/standalone/public/
 
-# Expose the port the app runs on
+RUN chmod +x start.sh
+
 EXPOSE 3000
 
-# Start the application using standalone server
-CMD ["node", ".next/standalone/server.js"] 
+CMD ["./start.sh"] 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     restart: always
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-example}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-meowmeow}
       POSTGRES_DB: ${POSTGRES_DB:-personal_relationship_manager}
     ports:
       - "5432:5432"
@@ -23,9 +23,9 @@ services:
       dockerfile: Dockerfile
     platform: linux/arm64
     ports:
-      - "3000:3000"
+      - "3002:3000"
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-example}@db:5432/${POSTGRES_DB:-personal_relationship_manager}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-meowmeow}@db:5432/${POSTGRES_DB:-personal_relationship_manager}?schema=public
       - NODE_ENV=production
     depends_on:
       db:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Wait for database to be ready
+echo "Waiting for database to be ready..."
+while ! npx prisma db push --skip-generate; do
+  echo "Database not ready yet, retrying in 5 seconds..."
+  sleep 5
+done
+
+# Run migrations
+echo "Running database migrations..."
+npx prisma migrate deploy
+
+# Start the application
+echo "Starting the application..."
+node .next/standalone/server.js 


### PR DESCRIPTION
This pull request includes several changes to the Docker and Docker Compose setup for the application to improve deployment and database initialization. The most important changes include modifying the `Dockerfile` to use a startup script, and adding a new startup script to handle database readiness and migrations.

Changes to Docker setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R27): Added execution permissions for `start.sh` and updated the command to use `start.sh` instead of directly starting the server.

Changes to Docker Compose configuration:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L8-R8): [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L8-R8) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L26-R28)

New startup script:

* [`start.sh`](diffhunk://#diff-65a5db1ae8f8e01ebdbbfafcf4e24618ad7cffe036bba92dce1390383e5c73e5R1-R16): Added a new script to wait for the database to be ready, run migrations, and then start the application.